### PR TITLE
Switch to ubuntu18.04 and a few tunings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ADD bootstrap.sh /
 
 RUN bash -x bootstrap.sh
 
-CMD ["/bin/etcd"]
+USER postgres
+
+WORKDIR /var/lib/postgresql
+
+ENTRYPOINT ["dumb-init"]
+
+CMD ["etcd"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,8 +12,8 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "ubuntu/xenial64"
-  config.vm.box_version = "20180410.0.0"
+  config.vm.box = "ubuntu/bionic64"
+  config.vm.box_version = "20180413.0.0"
   ENV["LC_ALL"]      = "en_US.UTF-8"
 
   # Disable automatic box update checking. If you disable this, then


### PR DESCRIPTION
* install most of the python modules from ubuntu packages
* don't setup pgdg, because postgresql-10 packages are already available
* get rid from patroni directory and download configs to postgres home
* create symlink .config/patroni/patronictl.yaml -> ../../postgres0.yml
* setup PATH, LC_ALL, LANG and EDITOR from /etc/bash.bashrc
* install Patroni from the master
* install dumb-init and use it as docker entrypoint